### PR TITLE
Test code: fix wrong order in calloc call (-Wcalloc-transposed-args)

### DIFF
--- a/apps/example.c
+++ b/apps/example.c
@@ -31,7 +31,7 @@ static int example_mayo(const mayo_params_t* p) {
     unsigned char *sk  = calloc(p->csk_bytes, 1);
 
     unsigned char *epk = calloc(p->epk_bytes, 1);
-    sk_t *esk = calloc(sizeof(sk_t), 1);
+    sk_t *esk = calloc(1, sizeof(sk_t));
 
     unsigned char *sig = calloc(p->sig_bytes + msglen, 1);
 

--- a/test/bench.c
+++ b/test/bench.c
@@ -99,7 +99,7 @@ static int bench_sig(const mayo_params_t *p, int runs, int csv) {
     unsigned char *pk  = calloc(p->cpk_bytes, 1);
     unsigned char *epk  = calloc(p->epk_bytes, 1);
     unsigned char *sk  = calloc(p->csk_bytes, 1);
-    sk_t *esk  = (sk_t *)calloc(sizeof(sk_t), 1);
+    sk_t *esk  = (sk_t *)calloc(1, sizeof(sk_t));
     unsigned char *sig = calloc(p->sig_bytes + m_len, 1);
     unsigned char *m   = calloc(m_len, 1);
     unsigned long long len = p->sig_bytes;


### PR DESCRIPTION
The calloc API is void* calloc(size_t num, size_t size); gcc14 added a warning when usign sizeof(.) for the first argument, e.g., calloc(sizeof(sk_t), 1) generates a warning as it likely should be calloc(1, sizeof(sk_t)).

```
MAYO-C/apps/example.c: In function ‘example_mayo’: MAYO-C/apps/example.c:34:31: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
   34 |     sk_t *esk = calloc(sizeof(sk_t), 1);
  ```

This commit fixes those warnings by swapping the arguments.